### PR TITLE
Fix invalid iOS device token decoding before sending to Intercom

### DIFF
--- a/ios/Classes/IntercomFlutterPlugin.m
+++ b/ios/Classes/IntercomFlutterPlugin.m
@@ -34,7 +34,9 @@ id unread;
     UnreadStreamHandler* unreadStreamHandler =
         [[UnreadStreamHandler alloc] init];
     [unreadChannel setStreamHandler:unreadStreamHandler];
-    
+    #if DEBUG
+    [Intercom enableLogging];
+    #endif
 }
 
 - (instancetype)initWithChannel:(FlutterMethodChannel *)channel {

--- a/ios/Classes/IntercomFlutterPlugin.m
+++ b/ios/Classes/IntercomFlutterPlugin.m
@@ -153,11 +153,6 @@ id unread;
     else if([@"displayMessageComposer" isEqualToString:call.method]) {
         NSString *message = call.arguments[@"message"];
         [Intercom presentMessageComposer:message];
-    } else if([@"sendTokenToIntercom" isEqualToString:call.method]){
-        NSString *token = call.arguments[@"token"];
-        NSData* encodedToken=[token dataUsingEncoding:NSUTF8StringEncoding];
-        [Intercom setDeviceToken:encodedToken];
-        result(@"Token set");
     }
     else if([@"sendTokenToIntercom" isEqualToString:call.method]) {
         NSString *token = call.arguments[@"token"];

--- a/ios/intercom_flutter.podspec
+++ b/ios/intercom_flutter.podspec
@@ -17,7 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Intercom'
   s.static_framework = true
-  s.dependency 'Intercom', '~> 7.1.0'
   s.ios.deployment_target = '10.0'
 end
 


### PR DESCRIPTION
I tried to use this non-official branch to integrate Intercom into a Flutter project I'm working on and the push notification was still not working on iOS as expected, after some investigations, I found the `sendTokenToIntercom` method call was implemented twice (I believe it might be a conflict resolution issue) and the 1st of them had an incorrect way of decoding `token` argument from `NSString` into `NSData` and we end up sending an invalid token to Intercom.

Additionally, I enabled Intercom logging and removed the explicit Intercom 7.1.0 pod dependency.